### PR TITLE
Retrieve the DN of users when searching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ extern {
     fn ldap_err2string(err: c_int) -> *const c_char;
     fn ldap_first_entry(ldap: *mut LDAP, result: *mut LDAPMessage) -> *mut LDAPMessage;
     fn ldap_next_entry(ldap: *mut LDAP, entry: *mut LDAPMessage) -> *mut LDAPMessage;
+    fn ldap_get_dn(ldap: *mut LDAP, entry: *mut LDAPMessage) -> *const c_char;
     fn ldap_get_values(ldap: *mut LDAP, entry: *mut LDAPMessage, attr: *const c_char) -> *const *const c_char;
     fn ldap_count_values(vals: *const *const c_char) -> c_int;
     fn ldap_value_free(vals: *const *const c_char);
@@ -360,6 +361,13 @@ impl RustLDAP {
             let mut map: HashMap<String,Vec<String>> = HashMap::new();
             let mut ber: *mut BerElement = ptr::null_mut();
             unsafe {
+                // Populate the "DN" of the user
+                let raw_dn = ldap_get_dn(self.ldap_ptr, entry);
+                let mut dn: Vec<String> = Vec::new();
+                dn.push(CStr::from_ptr(raw_dn).to_owned().into_string().unwrap_or("<Invalid DN>".to_string()));
+                map.insert("dn".to_string(), dn);
+                ldap_memfree(raw_dn as *mut c_void);
+
                 let mut attr: *const c_char = ldap_first_attribute(self.ldap_ptr, entry, &mut ber);
 
                 while !attr.is_null() {
@@ -385,7 +393,6 @@ impl RustLDAP {
                     ldap_value_free(raw_vals);
                     ldap_memfree(attr as *mut c_void);
                     attr = ldap_next_attribute(self.ldap_ptr, entry, ber)
-
                 }
 
                 // Free the BerElement and advance to the next entry.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,6 +468,9 @@ mod tests {
         //make sure we got something back
         assert!(search_res.len() == 1);
 
+        // make sure the DN is searched and returned correctly
+        assert_eq!(search_res[0]["dn"][0], "uid=tesla,dc=example,dc=com");
+
         for result in search_res {
             println!("simple search result: {:?}", result);
             for (key, value) in result {
@@ -491,6 +494,9 @@ mod tests {
 
         //make sure we got something back
         assert!(search_res.len() == 1);
+
+        // make sure the DN is searched and returned correctly
+        assert_eq!(search_res[0]["dn"][0], "uid=euler,dc=example,dc=com");
 
         for result in search_res {
             println!("search result: {:?}", result);


### PR DESCRIPTION
Not sure if this is the right way -- since we do not keep the LDAP entries around, the best way I can find to retrieve the user's DN is during the populating of the entry's hashmaps.